### PR TITLE
Check current branch for issues

### DIFF
--- a/backend/src/services/secret-sync/secret-sync-maps.ts
+++ b/backend/src/services/secret-sync/secret-sync-maps.ts
@@ -172,6 +172,11 @@ export const DESTINATION_DUPLICATE_CHECK_MAP: Record<SecretSync, DestinationDupl
 
     const wildcardValues = ["*", ""];
 
+    // First check if both configs have the same scope
+    if (existingConfig.scope !== newConfig.scope) {
+      return false;
+    }
+
     if (
       (newConfig.scope as string) === "group"
         ? existingConfig.groupId !== newConfig.groupId


### PR DESCRIPTION
# Description 📣

This PR fixes a bug in the GitLab secret sync duplicate detection logic. Previously, the system would compare `groupId` or `projectId` for GitLab secret sync configurations without first verifying that both configurations had the same `scope` (e.g., "group" vs. "project"). This could lead to incorrect duplicate detection when comparing syncs with different scopes. The fix adds a preliminary check to ensure scopes match before proceeding with ID comparisons, preventing false positives or negatives.

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

The following tests were run to verify the changes:

```sh
# Run linter
npm run lint

# Run type checks
npm run type-check

# Run backend unit tests
npm run test:backend
```

All checks passed, confirming no regressions and correct type inference.

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

---
<a href="https://cursor.com/background-agent?bcId=bc-9e88173d-7a46-45a5-84a2-e8eff4298bbc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9e88173d-7a46-45a5-84a2-e8eff4298bbc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

